### PR TITLE
make sure content-type is signed

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ async function verifySignature(request) {
         method: request.method,
         headers: headersToSign,
         body: request.body,
-        aws: { datetime: datetime }
+        aws: { datetime: datetime, allHeaders:true }
     });
 
     // All we need is the signature component of the Authorization header


### PR DESCRIPTION
For a request like:
```
aws s3 cp --endpoint-url https://cloudflare-b2-proxy.foo.workers.dev hello.txt s3://foo/hello.txt
```
the request `Authorization` header's `SignedHeaders` also includes the `content-type` header. 
```
aws --version
aws-cli/2.9.23 Python/3.11.1 Darwin/20.6.0 source/x86_64 prompt/off
```
2.9.23 was [released](https://github.com/aws/aws-cli/releases/tag/2.9.23) on Feb 10, 2023 so I suspect this is newer behavior.

https://github.com/mhart/aws4fetch/blob/master/src/main.js#L25 appears to ignore that header.

Before:
In the request `Authorization` header:
```SignedHeaders=content-md5;content-type;host;x-amz-content-sha256;x-amz-date```
In the signedRequest `Authorization` header:
```SignedHeaders=content-md5;host;x-amz-content-sha256;x-amz-date```

After:
In the request `Authorizatio`n header:
```SignedHeaders=content-md5;content-type;host;x-amz-content-sha256;x-amz-date```
In the signedRequest Authorization header:
```SignedHeaders=content-md5;content-type;host;x-amz-content-sha256;x-amz-date```