### PR TITLE
Add ~/.aws/ caveat to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ You can use any S3 SDK or CLI to send requests as long as you set the endpoint U
 
 ```bash
 % export AWS_ACCESS_KEY_ID=<your b2 application key id>
-% export AWS_SECRET_ACCESS_KEY=<your b2 application key> 
+% export AWS_SECRET_ACCESS_KEY=<your b2 application key>
+% export AWS_REGION=<your b2 bucket's region>
 % aws s3 cp --endpoint-url https://cloudflare-b2-proxy.<your-subdomain>.workers.dev hello.txt s3://<your-bucket-name>/hello.txt
 upload: hello.txt to s3://<your-bucket-name>/hello.txt
 ```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ You can use any S3 SDK or CLI to send requests as long as you set the endpoint U
 % aws s3 cp --endpoint-url https://cloudflare-b2-proxy.<your-subdomain>.workers.dev hello.txt s3://<your-bucket-name>/hello.txt
 upload: hello.txt to s3://<your-bucket-name>/hello.txt
 ```
+__Note that your configuration in `~/.aws/` may override authentication and/or region and cause 403s.__
 
 Informal testing suggests that there is negligible performance overhead imposed by the signature verification and resigning.
 


### PR DESCRIPTION
I found that my aws config overrode things I didn't expect. Deleting that config helped make the documentation reproducible although not generally a good practice.